### PR TITLE
Sync user store state across browser and Electron

### DIFF
--- a/src/renderer/stores/userStore.ts
+++ b/src/renderer/stores/userStore.ts
@@ -2,20 +2,43 @@ import { API_BASE_URL, GET_USER, GET_USER_API } from "@/constants";
 import type { UserState } from "@/main/model/user.model";
 import { create } from "zustand";
 
-export const useUserStoreRestful = create<UserState>((set, get) => ({
-  userName: "Default",
-  fetchUser: async () => {
-    const data = await fetch(`${API_BASE_URL + GET_USER_API}`).then(res => res.json());
-    set({ userName: data.name });
-    //broadcastUserUpdate(data.name);
-  },
-}));
+// BroadcastChannel은 브라우저와 Electron 간 상태 동기화를 위한 채널이다.
+const userChannel = new BroadcastChannel('user-store');
 
-export const useUserStoreIPC = create<UserState>((set, get) => ({
-  userName: "Default",
-  fetchUser: async () => {
-    const res = await window.electron.ipcRenderer.invoke(GET_USER);
-    set({ userName: res.name });
-    //broadcastUserUpdate(res.name);
-  },
-}));
+// 다른 창에서 전달된 상태 변경을 구독한다.
+const subscribeToUserUpdates = (set: (partial: Partial<UserState>) => void) => {
+  userChannel.onmessage = (event) => {
+    set({ userName: event.data });
+  };
+};
+
+// 상태 변경을 다른 창에 전파한다.
+const broadcastUserUpdate = (userName: string) => {
+  userChannel.postMessage(userName);
+};
+
+export const useUserStoreRestful = create<UserState>((set) => {
+  subscribeToUserUpdates(set);
+
+  return {
+    userName: "Default",
+    fetchUser: async () => {
+      const data = await fetch(`${API_BASE_URL + GET_USER_API}`).then(res => res.json());
+      set({ userName: data.name });
+      broadcastUserUpdate(data.name);
+    },
+  };
+});
+
+export const useUserStoreIPC = create<UserState>((set) => {
+  subscribeToUserUpdates(set);
+
+  return {
+    userName: "Default",
+    fetchUser: async () => {
+      const res = await window.electron.ipcRenderer.invoke(GET_USER);
+      set({ userName: res.name });
+      broadcastUserUpdate(res.name);
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- sync `userStore.ts` across Browser and Electron using `BroadcastChannel`
- emit state changes via `broadcastUserUpdate` and listen via `subscribeToUserUpdates`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847740482c48326b898ef5be296e9e0