### PR TITLE
Implement BroadcastChannel request-response

### DIFF
--- a/src/renderer/stores/userStore.ts
+++ b/src/renderer/stores/userStore.ts
@@ -5,20 +5,49 @@ import { create } from "zustand";
 // BroadcastChannel은 브라우저와 Electron 간 상태 동기화를 위한 채널이다.
 const userChannel = new BroadcastChannel('user-store');
 
+// 창이 닫힐 때 채널을 정리한다.
+window.addEventListener('beforeunload', () => {
+  userChannel.close();
+});
+
+type UserMessage =
+  | { type: 'request' }
+  | { type: 'response'; userName: string }
+  | { type: 'update'; userName: string };
+
 // 다른 창에서 전달된 상태 변경을 구독한다.
-const subscribeToUserUpdates = (set: (partial: Partial<UserState>) => void) => {
+const subscribeToUserUpdates = (
+  set: (partial: Partial<UserState>) => void,
+  get: () => UserState
+) => {
   userChannel.onmessage = (event) => {
-    set({ userName: event.data });
+    const message = event.data as UserMessage;
+
+    if (message.type === 'request') {
+      const { userName } = get();
+      if (userName) {
+        userChannel.postMessage({ type: 'response', userName });
+      }
+    } else if (message.type === 'response' || message.type === 'update') {
+      set({ userName: message.userName });
+    }
   };
 };
 
 // 상태 변경을 다른 창에 전파한다.
 const broadcastUserUpdate = (userName: string) => {
-  userChannel.postMessage(userName);
+  const message: UserMessage = { type: 'update', userName };
+  userChannel.postMessage(message);
 };
 
-export const useUserStoreRestful = create<UserState>((set) => {
-  subscribeToUserUpdates(set);
+const broadcastUserRequest = () => {
+  const message: UserMessage = { type: 'request' };
+  userChannel.postMessage(message);
+};
+
+export const useUserStoreRestful = create<UserState>((set, get) => {
+  subscribeToUserUpdates(set, get);
+  broadcastUserRequest();
 
   return {
     userName: "Default",
@@ -30,8 +59,9 @@ export const useUserStoreRestful = create<UserState>((set) => {
   };
 });
 
-export const useUserStoreIPC = create<UserState>((set) => {
-  subscribeToUserUpdates(set);
+export const useUserStoreIPC = create<UserState>((set, get) => {
+  subscribeToUserUpdates(set, get);
+  broadcastUserRequest();
 
   return {
     userName: "Default",


### PR DESCRIPTION
## Summary
- allow user stores to share their userName across windows
- send initial request message on store setup
- respond to request with current userName
- close BroadcastChannel on window unload

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684779233a048326b3de4ae9fd6e5a0a